### PR TITLE
Suggestion: Moved the tabs out of the navbar

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,33 +1,46 @@
-import React from 'react';
+import React from "react";
 import { Link } from "react-router-dom";
-import { Navbar, Nav, Container } from 'react-bootstrap';
-import './NavBar.css';
+import { Navbar, Nav, Container } from "react-bootstrap";
 
 const NavBar = () => {
   return (
-    <Navbar bg="primary" variant="dark">
+    <>
+      <Navbar bg="primary" variant="dark">
+        <Container>
+          <Navbar.Brand>Tool Swappin</Navbar.Brand>
+        </Container>
+      </Navbar>
       <Container>
-        <Navbar.Brand>Tool Swappin</Navbar.Brand>
         <Nav variant="tabs">
           <Nav.Item>
-            <Nav.Link as={Link} to="/" id="home" eventKey="link-1">Home</Nav.Link>
+            <Nav.Link as={Link} to="/" id="home" eventKey="link-1">
+              Home
+            </Nav.Link>
           </Nav.Item>
           <Nav.Item>
-            <Nav.Link as={Link} to="/search" id="search" eventKey="link-2">Search</Nav.Link>
+            <Nav.Link as={Link} to="/search" id="search" eventKey="link-2">
+              Search
+            </Nav.Link>
           </Nav.Item>
           <Nav.Item>
-            <Nav.Link as={Link} to="/login" id="login" eventKey="link-3">Login</Nav.Link>
+            <Nav.Link as={Link} to="/login" id="login" eventKey="link-3">
+              Login
+            </Nav.Link>
           </Nav.Item>
           <Nav.Item>
-            <Nav.Link as={Link} to="/profile" id="profile" eventKey="link-4">Profile</Nav.Link>
+            <Nav.Link as={Link} to="/profile" id="profile" eventKey="link-4">
+              Profile
+            </Nav.Link>
           </Nav.Item>
           <Nav.Item>
-            <Nav.Link as={Link} to="/messages" id="messages" eventKey="link-5">Messages</Nav.Link>
+            <Nav.Link as={Link} to="/messages" id="messages" eventKey="link-5">
+              Messages
+            </Nav.Link>
           </Nav.Item>
         </Nav>
       </Container>
-    </Navbar>
-  )
-}
+    </>
+  );
+};
 
 export default NavBar;


### PR DESCRIPTION
**Why this was happening**
The styling looked weird because the tabs were _in_ the navbar. This meant that the dark navbar's text color (white) displayed **through** the tab items. To fix this, I just moved the tabs out of the navbar :)

![image](https://user-images.githubusercontent.com/6249465/134960253-9ca73b83-129d-4870-a8c3-c802aa3e1999.png)

The tabs can still live in `Navbar.js` since it "navigates" the page, just using tabs... yknow?